### PR TITLE
ClearTimeout on unmount fixed

### DIFF
--- a/src/lib/hooks/resendOTP.js
+++ b/src/lib/hooks/resendOTP.js
@@ -22,7 +22,7 @@ const useResendOTP = ({
       }, timeInterval);
     }
     return () => {
-      clearTimeout(timeout);
+      clearTimeout(timeout.current);
     };
   }, [onTimerComplete, remainingTime, timeInterval]);
 


### PR DESCRIPTION
Fixed: (#8 ): `clearTimout` now changed to `clearTimeout.current`